### PR TITLE
Elasticsearch aws

### DIFF
--- a/connector/elasticsearch-connector.js
+++ b/connector/elasticsearch-connector.js
@@ -492,6 +492,8 @@
              data: JSON.stringify(requestData),
              dataType: 'json',
              beforeSend: function (xhr) {
+                xhr.setRequestHeader('Accept', null);
+                xhr.setRequestHeader('Content-Type', 'application/json');
                  if (connectionData.elasticsearchAuthenticate && tableau.username) {
                      xhr.setRequestHeader("Authorization", "Basic " +
                          btoa(tableau.username + ":" + tableau.password));
@@ -499,11 +501,8 @@
 
              },
              success: function (data) {
-
                  clearError();
-
                  var result = processSearchResults(data);
-
                  cb(null, result.scrollId);
              },
              error: function (xhr, ajaxOptions, err) {
@@ -524,20 +523,16 @@
              return;
          }
 
-         var connectionUrl = connectionData.elasticsearchUrl + '/_search/scroll';
-
-         var requestData = {
-             scroll: '5m',
-             scroll_id: scrollId
-         };
+         var connectionUrl = connectionData.elasticsearchUrl + '/_search/scroll?scroll=5m&scroll_id='+scrollId;
 
          var xhr = $.ajax({
              url: connectionUrl,
              method: 'POST',
              processData: false,
-             data: JSON.stringify(requestData),
              dataType: 'json',
              beforeSend: function (xhr) {
+                xhr.setRequestHeader('Accept', null);
+                xhr.setRequestHeader('Content-Type', 'application/json')
                  if (connectionData.elasticsearchAuthenticate && tableau.username) {
                      xhr.setRequestHeader("Authorization", "Basic " +
                          btoa(tableau.username + ":" + tableau.password));

--- a/connector/elasticsearch-connector.js
+++ b/connector/elasticsearch-connector.js
@@ -505,7 +505,7 @@
                  clearError();
 
                  var result = processSearchResults(data);
-                 
+
                  cb(null, result.scrollId);
              },
              error: function (xhr, ajaxOptions, err) {

--- a/connector/elasticsearch-connector.js
+++ b/connector/elasticsearch-connector.js
@@ -492,8 +492,8 @@
              data: JSON.stringify(requestData),
              dataType: 'json',
              beforeSend: function (xhr) {
-                xhr.setRequestHeader('Accept', null);
-                xhr.setRequestHeader('Content-Type', 'application/json');
+                 xhr.setRequestHeader('Accept', null);
+                 xhr.setRequestHeader('Content-Type', 'application/json');
                  if (connectionData.elasticsearchAuthenticate && tableau.username) {
                      xhr.setRequestHeader("Authorization", "Basic " +
                          btoa(tableau.username + ":" + tableau.password));
@@ -501,8 +501,11 @@
 
              },
              success: function (data) {
+
                  clearError();
+
                  var result = processSearchResults(data);
+                 
                  cb(null, result.scrollId);
              },
              error: function (xhr, ajaxOptions, err) {


### PR DESCRIPTION
Due Elasticsearch from Amazon Services version is older (1.5.2), it does not works properly requesting scroll in body field.

Besides, the first Post request needs to **remove** `Accept` header and **add** `Content-Type` to work properly.
