### PR TITLE
Fix exceptions loading :dist inside 10.0

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -140,6 +140,9 @@ require('load-grunt-tasks')(grunt);
               files: {
                 'dist/elasticsearch-connector.min.js': [
                         'dist-tmp/jquery*.js',
+                        'dist-tmp/ace.js',
+                        'dist-tmp/theme-github.js',
+                        'dist-tmp/mode-json.js',
                         'dist-tmp/bootstrap.js',
                         'dist-tmp/bootstrap3-typeahead.js',
                         'dist-tmp/bootstrap-datepicker.js',

--- a/connector/elasticsearch-connector.js
+++ b/connector/elasticsearch-connector.js
@@ -163,8 +163,9 @@ var elasticsearchConnector = (function () {
                 getNextScrollResult(true, lastRecordToken, function (err, result) {
                     if(err){
                         abort(err, true);
+                    } else {
+                      console.log('[getTableData] processed next scroll result, count: ' + result.results.length);
                     }
-                    console.log('[getTableData] processed next scroll result, count: ' + result.results.length);
                 })
             }
         }


### PR DESCRIPTION
Addresses #32 
- a clean build depends on ace and its dependencies that aren't distributed according to the gruntfile or the manual copy steps.
- nb, this doesn't cover the elasticsearch logo, but that is also missing in :dist
