### PR TITLE
Fixes issue # 50 An Error occured while communicating with the data s…

### DIFF
--- a/connector/elasticsearch-connector.js
+++ b/connector/elasticsearch-connector.js
@@ -807,7 +807,10 @@ var elasticsearchConnector = (function () {
                     }
                     
                     fieldName = toSafeTableauFieldName(field);
-
+                    
+                    // convert dateField to String before calling .replace() on it
+				    val = val + ''; 
+                    
                     item[fieldName] = moment.utc(val.replace(' +', '+')
                         .replace(' -', '-')).format('YYYY-MM-DD HH:mm:ss');
                 });


### PR DESCRIPTION
This issue occurs when date fields are not type String. In such cases .replace() returns undefined and moment.utc(...) throws exception. As a result user is not able to retrieve any data while using (Search Result Mode). 

To fix this issue I added logic, which will convert date fields (val) to string before calling moment.utc(...). 
