### PR TITLE
Fix to set correct request headers - fix AWS Elasticsearch service issue

### DIFF
--- a/connector/elasticsearch-connector.js
+++ b/connector/elasticsearch-connector.js
@@ -1379,6 +1379,9 @@ var elasticsearchConnector = (function () {
 
     var beforeSendAddAuthHeader = function(xhr, connectionData){
         
+        xhr.setRequestHeader('Accept', null);
+        xhr.setRequestHeader('Content-Type', 'application/json');
+
         var creds = getAuthCredentials(connectionData);
 
         if (connectionData.elasticsearchAuthenticate && creds.username) {


### PR DESCRIPTION
Correctly set request headers.

This should fix an older issue seen with the AWS Elasticsearch service.