### PR TITLE
Fix URL validation where host ends with digits

### DIFF
--- a/connector/app.js
+++ b/connector/app.js
@@ -615,7 +615,7 @@ var app = (function () {
 
     var isValidUrl = function (str) {
         var pattern = new RegExp('^(https?:\/\/)?' + // protocol
-            '((([a-z\\d]([a-z\\d-]*[a-z\\d])*)\.)+[a-z]{2,}|' + // domain name
+            '((([a-z\\d]([a-z\\d-]*[a-z\\d])*)\.)+[a-z\\d]{2,}|' + // domain name
             '((\\d{1,3}\\.){3}\\d{1,3}))' + // OR ip (v4) address
             '(\\:\\d+)?(\/[-a-z\\d%_.~+]*)*' + // port and path
             '(\\?[;&a-z\\d%_.~+=-]*)?' + // query string


### PR DESCRIPTION
Resolves #58 

Support host name in Elasticsearch URL that end in digits