### PR TITLE
Use the safe field name earlier for date fields

### DIFF
--- a/connector/elasticsearch-connector.js
+++ b/connector/elasticsearch-connector.js
@@ -896,24 +896,23 @@ var elasticsearchConnector = (function () {
 
                 // Copy over any formatted value to the source object
                 _.each(connectionData.dateFields, function (field) {
-
-                    if (!item[field]) {
+                    fieldName = toSafeTableauFieldName(field);
+                    
+		    if (!item[fieldName]) {
                         return;
                     }
 
-                    if( !_.isString(item[field])){
+                    if( !_.isString(item[fieldName])){
                         return;
                     }
 
                     val = null;
-                    if(_.isArray(item[field])){
-                        val = item[field][0]
+                    if(_.isArray(item[fieldName])){
+                        val = item[fieldName][0]
                     }
                     else{
-                        val = item[field]
+                        val = item[fieldName]
                     }
-                    
-                    fieldName = toSafeTableauFieldName(field);
                     
                     // convert dateField to String before calling .replace() on it
 				    val = val + ''; 


### PR DESCRIPTION
For names that are converted to a safe name, the item is skipped because it doesn't match.