### PR TITLE
Incremental date precision

### DIFF
--- a/README.md
+++ b/README.md
@@ -345,6 +345,10 @@ column is stored and used on subsequent extracts as the starting value.  E.g., i
 then the next time an incremental extract is processed, the query to Elasticsearch will filter on the `@timestamp` field for values
 greater than `1/1/2000 00:00:00`.
 
+A system generated field will be added to your Tableau datasource with the name of the incremental refresh column preprended with '_incremental_'.  This is used
+for internal storage of processing of incremental extracts.  Example, if you select a field named 'id' to use as the incremental refresh column, then
+you will see a column named '_incremental_id' in your data source.
+
 Generally the value should be unique and be automatically incremented as new data is added to Elasticsearch (why a timestamp or auto incrementing sequence number are good choices).
 
 For more information refer to: 

--- a/connector/elasticsearch-connector.tmpl.html
+++ b/connector/elasticsearch-connector.tmpl.html
@@ -117,6 +117,14 @@
 
                     </label>
                   </div>
+                  <!--
+                  <div class="checkbox">
+                    <label>
+                      <input type="checkbox" data-bind="checked: includeMilliseconds">Include milliseconds in dates?
+                      <i data-bind="bootstrapPopover, bootstrapPopoverType: 'rich', bootstrapPopoverContent: useIncludeMilliseconds" class="glyphicon glyphicon-info-sign" title="Include milliseconds in dates?"></i>
+                    </label>
+                  </div>
+                -->
                   <div class="checkbox">
                     <label>
                       <input type="checkbox" data-bind="checked: useEsFieldNameAsAliases">Improve Field Names?
@@ -179,6 +187,12 @@
                         <label for="inputBatchSize">Incremental Refresh Column</label>
                         <select class="form-control" data-bind="options: incrementalRefreshColumns, value: incrementalRefreshColumn, optionsText: 'name', optionsValue: 'name'"></select>
                     </div>
+                    <!--
+                    <div class="form-group required" data-bind="visible: usingDateForIncrementalRefresh">
+                        <label for="inputIncrementalRefreshColDateFormat">Date Format</label>
+                        <input type="text" class="form-control" id="inputIncrementalRefreshColDateFormat" placeholder="Enter date format" data-bind="value: incrementalRefreshColDateFormat">
+                    </div>
+                    -->
 
                     <div class="form-group required">
                         <label for="inputBatchSize">Batch record size for each response</label>


### PR DESCRIPTION
Resolves #70 

Add support to use raw values from Elasticsearch documents for the incremental refresh values.  This fixes an issue where dates were being parsed and millisecond precision was lost.

Whatever precision of data stored in Elasticsearch will be used for the incremental refresh value.  Additionally a system generated field (prepended with '_incremental_') will be added to the datasource to store the incremental refresh column's value in the data source.