### PR TITLE
Simplify fix for date precision in incremental refresh

### DIFF
--- a/README.md
+++ b/README.md
@@ -345,10 +345,6 @@ column is stored and used on subsequent extracts as the starting value.  E.g., i
 then the next time an incremental extract is processed, the query to Elasticsearch will filter on the `@timestamp` field for values
 greater than `1/1/2000 00:00:00`.
 
-A system generated field will be added to your Tableau datasource with the name of the incremental refresh column preprended with '_incremental_'.  This is used
-for internal storage of processing of incremental extracts.  Example, if you select a field named 'id' to use as the incremental refresh column, then
-you will see a column named '_incremental_id' in your data source.
-
 Generally the value should be unique and be automatically incremented as new data is added to Elasticsearch (why a timestamp or auto incrementing sequence number are good choices).
 
 For more information refer to: 

--- a/connector/app.js
+++ b/connector/app.js
@@ -27,7 +27,6 @@ var app = (function () {
 
         self.useIncrementalRefresh = ko.observable(false);
         self.incrementalRefreshColumns = ko.observableArray([]);
-        self.rawIncrementalRefreshColumn = ko.observable();
         self.incrementalRefreshColumn = ko.observable();
         self.usingDateForIncrementalRefresh = ko.observable(false);
         self.incrementalRefreshColDateFormat = ko.observable();
@@ -250,7 +249,6 @@ var app = (function () {
                 useSyncClientWorkaround: self.useSyncClientWorkaround(),
                 useIncrementalRefresh: self.useIncrementalRefresh(),
                 incrementalRefreshColumn: self.incrementalRefreshColumn(),
-                rawIncrementalRefreshColumn: self.rawIncrementalRefreshColumn(),
                 usingDateForIncrementalRefresh: self.usingDateForIncrementalRefresh(),
                 incrementalRefreshColDateFormat: self.incrementalRefreshColDateFormat(),
                 batchSize: self.batchSize(),
@@ -811,8 +809,6 @@ var app = (function () {
     });
 
     vm.incrementalRefreshColumn.subscribe(function (newValue) {
-
-        vm.rawIncrementalRefreshColumn("_incremental_" + newValue);
 
         var esDateFields = elasticsearchConnector.getElasticsearchDateFields();
 

--- a/connector/elasticsearch-connector.js
+++ b/connector/elasticsearch-connector.js
@@ -723,7 +723,7 @@ var elasticsearchConnector = (function () {
                     }
                     incrementValue = incrementValue.format(format);
 
-                    console.log("[openSearchScrollWindow] Formatted incremental refresh column vvalue: , format: ", incrementValue, format)
+                    console.log("[openSearchScrollWindow] Formatted incremental refresh column value, format:", incrementValue, format)
                 }
 
                 var filter = { range: {} };

--- a/connector/elasticsearch-connector.tmpl.html
+++ b/connector/elasticsearch-connector.tmpl.html
@@ -187,12 +187,12 @@
                         <label for="inputBatchSize">Incremental Refresh Column</label>
                         <select class="form-control" data-bind="options: incrementalRefreshColumns, value: incrementalRefreshColumn, optionsText: 'name', optionsValue: 'name'"></select>
                     </div>
-                    <!--
+<!--
                     <div class="form-group required" data-bind="visible: usingDateForIncrementalRefresh">
                         <label for="inputIncrementalRefreshColDateFormat">Date Format</label>
                         <input type="text" class="form-control" id="inputIncrementalRefreshColDateFormat" placeholder="Enter date format" data-bind="value: incrementalRefreshColDateFormat">
                     </div>
-                    -->
+                -->
 
                     <div class="form-group required">
                         <label for="inputBatchSize">Batch record size for each response</label>


### PR DESCRIPTION
Remove system generated fields, and use date format from type mapping when creating value to use in ES query to get next set of incremental data.