### PR TITLE
Resolves #69 - Support to select which index to use for type selection when selecting an alias

### DIFF
--- a/README.md
+++ b/README.md
@@ -221,6 +221,7 @@ The Elasticsearch connector UI includes the following fields:
 | Username | String | If 'Use HTTP Basic Auth' is checked, this is the user name|
 | Password | String | If 'Use HTTP Basic Auth' is checked, this is the password |
 | Index name | String | \[Required\] Name of the index in the Elasticsearch cluster |
+| Index Filter for Type Selection | String | If the index selected is an alias, this selection is required to choose the index to filter types by.  Only types from this selection will be available in the 'Type' selection |
 | Type | String | \[Required\] Name of the type in the Elasticsearch cluster to query |
 | Override Field Defaults | Boolean | If selected, then additional options to override default handling of fields is available |
 | Parse date fields in local time? | Boolean | If selected then all date or timestamp fields will be parsed in local time, the default (unselected) will parse as UTC |

--- a/connector/app.js
+++ b/connector/app.js
@@ -430,6 +430,7 @@ var app = (function () {
 
                     _.each(indices, function (index) {
 
+                        // If the index is an alias, then only return types part of the selected index alias filter
                         var isAlias = _.find(self.aliases(), function(alias){
                             return alias == self.elasticsearchIndex();
                         });
@@ -845,10 +846,23 @@ var app = (function () {
 
     vm.elasticsearchIndex.subscribe(function (newValue) {
 
-        var isAlias = _.find(vm.aliases(), function(alias){
-            return alias == newValue;
-        });
-        vm.selectedAliasForIndex(isAlias ? true : false);
+        if (vm.aliases().length == 0) {
+            vm.getElasticsearchAliases(function (err, aliases) {
+                var uniqueAliasList = (_.uniq(aliases));
+                vm.aliases(uniqueAliasList);
+
+                var isAlias = _.find(vm.aliases(), function(alias){
+                    return alias == newValue;
+                });
+                vm.selectedAliasForIndex(isAlias ? true : false);
+            });
+        }
+        else{
+            var isAlias = _.find(vm.aliases(), function(alias){
+                return alias == newValue;
+            });
+            vm.selectedAliasForIndex(isAlias ? true : false);
+        }
 
         vm.elasticsearchAliasIndex("");
         vm.elasticsearchType("");

--- a/connector/app.js
+++ b/connector/app.js
@@ -11,6 +11,10 @@ var app = (function () {
         self.password = ko.observable();
         self.elasticsearchUrl = ko.observable();
         self.elasticsearchIndex = ko.observable();
+        self.elasticsearchAliasIndex = ko.observable();
+
+        self.aliases = ko.observable([]);
+        self.selectedAliasForIndex = ko.observable(false);
 
         self.overrideFieldDefaults = ko.observable(false);
         self.allDatesAsLocalTime = ko.observable(false);
@@ -189,12 +193,40 @@ var app = (function () {
                     if (err) {
                         return self.abort(err);
                     }
-                    var sourceData = indices.concat(_.uniq(aliases));
+                    var uniqueAliasList = (_.uniq(aliases));
+                    var sourceData = indices.concat(uniqueAliasList);
+
+                    self.aliases(uniqueAliasList);
 
                     // Return the actual list of items to the control
                     cb(sourceData);
                 });
 
+            });
+        };
+
+        self.elasticsearchAliasIndexSource = function (something, cb) {
+
+            $('.index-icon').toggleClass('hide');
+
+            self.getElasticsearchRawAliases(function (err, aliases) {
+
+                $('.index-icon').toggleClass('hide');
+
+                if (err) {
+                    return self.abort(err);
+                }
+
+                sourceData = [];
+
+                _.forEach(aliases, function(indexAliases, indexName) {
+                    if(indexAliases.aliases[self.elasticsearchIndex()]){
+                        sourceData = sourceData.concat(indexName);
+                    }
+                });
+
+                // Return the actual list of items to the control
+                cb(sourceData);
             });
         };
 
@@ -238,6 +270,7 @@ var app = (function () {
                 elasticsearchUsername: self.username(),
                 elasticsearchPassword: self.password(),
                 elasticsearchIndex: self.elasticsearchIndex(),
+                elasticsearchAliasIndex: self.elasticsearchAliasIndex(),
                 elasticsearchType: self.elasticsearchType(),
                 overrideFieldDefaults: self.overrideFieldDefaults(),
                 allDatesAsLocalTime: self.allDatesAsLocalTime(),
@@ -396,8 +429,15 @@ var app = (function () {
                     var esTypes = [];
 
                     _.each(indices, function (index) {
-                        var types = _.keys(data[index].mappings);
 
+                        var isAlias = _.find(self.aliases(), function(alias){
+                            return alias == self.elasticsearchIndex();
+                        });
+                        if(isAlias && index != self.elasticsearchAliasIndex()){
+                            return;
+                        }
+
+                        var types = _.keys(data[index].mappings);
                         esTypes = esTypes.concat(types);
                     });
 
@@ -502,6 +542,46 @@ var app = (function () {
                 }
             });
         };
+
+        self.getElasticsearchRawAliases = function (cb) {
+            
+                        var connectionData = tableauData.getUnwrapped();
+            
+                        if (!connectionData) {
+                            console.log("[App] getElasticsearchIndices - no connection data, nothing to do");
+                            return;
+                        }
+                        if (!connectionData.elasticsearchUrl) {
+                            console.log("[App] getElasticsearchIndices - no Elasticsearch URL, nothing to do");
+                            return;
+                        }
+            
+                        var connectionUrl = connectionData.elasticsearchUrl + '/_aliases';
+            
+                        var xhr = $.ajax({
+                            url: connectionUrl,
+                            method: 'GET',
+                            contentType: 'application/json',
+                            dataType: 'json',
+                            beforeSend: function (xhr) {
+                                _beforeSendAddAuthHeader(xhr, connectionData);
+                            },
+                            success: function (data) {
+            
+                                self.errorMessage("");
+            
+                                cb(null, data);
+                            },
+                            error: function (xhr, ajaxOptions, err) {
+                                if (xhr.status == 0) {
+                                    cb('Unable to get Elasticsearch aliases, unable to connect to host or CORS request was denied');
+                                }
+                                else {
+                                    cb("Unable to get Elasticsearch aliases, status code:  " + xhr.status + '; ' + xhr.responseText + "\n" + err);
+                                }
+                            }
+                        });
+                    };
 
         self.getElasticsearchFieldData = function (cb, initialLoad) {
             var messages = [];
@@ -609,6 +689,18 @@ var app = (function () {
             }
             else {
                 validation.elasticsearchIndex = false;
+            }
+
+            var isAlias = _.find(self.aliases(), function(alias){
+                return alias == self.elasticsearchIndex();
+            });
+            
+            if (isAlias && !self.elasticsearchAliasIndex()) {
+                validation.messages.push("Elasticsearch Alias Index is required");
+                validation.elasticsearchAliasIndex = true
+            }
+            else {
+                validation.elasticsearchAliasIndex = false;
             }
 
             if (!self.elasticsearchType()) {
@@ -739,6 +831,7 @@ var app = (function () {
     vm.elasticsearchUrl.subscribe(function (newValue) {
 
         vm.elasticsearchIndex("");
+        vm.elasticsearchAliasIndex("");
         vm.elasticsearchType("");
 
         vm.previewFields.removeAll();
@@ -751,6 +844,33 @@ var app = (function () {
     });
 
     vm.elasticsearchIndex.subscribe(function (newValue) {
+
+        var isAlias = _.find(vm.aliases(), function(alias){
+            return alias == newValue;
+        });
+        vm.selectedAliasForIndex(isAlias ? true : false);
+
+        vm.elasticsearchAliasIndex("");
+        vm.elasticsearchType("");
+
+        vm.previewFields.removeAll();
+        vm.previewData.removeAll();
+
+        vm.aggregations.clear();
+        tableauData.updateProperties(vm.getTableauConnectionData());
+
+        vm.getElasticsearchFieldData(updateIncrementalRefreshColumns);
+    });
+
+    vm.selectedAliasForIndex.subscribe(function(newValue){
+
+        // If not using an alias for the index - then duplicate the value
+        if(!newValue){
+            vm.elasticsearchAliasIndex(vm.elasticsearchIndex());
+        }
+    });
+
+    vm.elasticsearchAliasIndex.subscribe(function (newValue) {
 
         vm.elasticsearchType("");
 

--- a/connector/elasticsearch-connector.js
+++ b/connector/elasticsearch-connector.js
@@ -359,13 +359,8 @@ var elasticsearchConnector = (function () {
                     var indexName = connectionData.elasticsearchIndex;
 
                     // Then we selected an alias... choose the last index with a matching type name
-                    // TODO: Let user choose which type from which index
                     if (data[connectionData.elasticsearchIndex] == null) {
-                        _.forIn(data, function (index, indexKey) {
-                            if (index.mappings[connectionData.elasticsearchType]) {
-                                indexName = indexKey;
-                            }
-                        });
+                        indexName = connectionData.elasticsearchAliasIndex;
                     }
 
                     var errMsg = null;

--- a/connector/elasticsearch-connector.js
+++ b/connector/elasticsearch-connector.js
@@ -358,9 +358,17 @@ var elasticsearchConnector = (function () {
 
                     var indexName = connectionData.elasticsearchIndex;
 
-                    // Then we selected an alias... choose the last index with a matching type name
+                    // Then we selected an alias... the actual index we use will be from the alias index filter selection
                     if (data[connectionData.elasticsearchIndex] == null) {
                         indexName = connectionData.elasticsearchAliasIndex;
+                        // Backwards compatibility where alias was not previously selected, use the last of all the alias' indices
+                        if(!indexName){
+                            _.forIn(data, function (index, indexKey) {
+                                if (index.mappings[connectionData.elasticsearchType]) {
+                                    indexName = indexKey;
+                                }
+                            });
+                        }
                     }
 
                     var errMsg = null;

--- a/connector/elasticsearch-connector.tmpl.html
+++ b/connector/elasticsearch-connector.tmpl.html
@@ -86,6 +86,19 @@
                     </input>
 
                 </div>
+                <div class="form-group required" data-bind="visible: selectedAliasForIndex, css: { 'has-error': validation().elasticsearchAliasIndex, 'has-feedback': validation().elasticsearchAliasIndex }">
+                    <label for="inputElasticsearchAliasIndexTypeahead">Index Filter for Type Selection</label>
+                    <i data-bind="bootstrapPopover" class="glyphicon glyphicon-info-sign" data-toggle="popover" data-trigger="hover" title="Index Filter for Type Selection"
+                        data-content="When choosing an alias for the index, this selection will filter types only from this index."></i>
+
+                    <input class="form-control" type="text" data-provide="typeahead" data-bind="typeahead, typeaheadSource: elasticsearchAliasIndexSource, value: elasticsearchAliasIndex"
+                        autocomplete="off" placeholder="Name of index within the alias to use for type selection">
+                    <span class="glyphicon glyphicon-remove form-control-feedback" aria-hidden="true" data-bind="visible: validation().elasticsearchAliasIndex"></span>
+                    <span class="sr-only" data-bind="if: validation().elasticsearchAliasIndex">(error)</span>
+                    <i class="index-icon glyphicon glyphicon-refresh icon-refresh-animate hide"></i>
+                    </input>
+
+                </div>
                 <div class="form-group required" data-bind="css: { 'has-error': validation().elasticsearchType, 'has-feedback': validation().elasticsearchType }">
                     <label for="inputElasticsearchTypeTypeahead">Type</label>
                     <input class="form-control" type="text" data-provide="typeahead" data-bind="typeahead, typeaheadSource: elasticsearchTypeSource, value: elasticsearchType"


### PR DESCRIPTION
Better support for type selection when using an alias

- Add new 'Alias Index for Type Selection' option in the UI displayed when selecting an alias
- This will filter the types based on the index selected
- Backward compatibility with old connector data that used indices but wont have the new 'alias index for type selection' field data provided