### PR TITLE
Better error handling in case that scroll timeout is exceeded

### DIFF
--- a/connector/elasticsearch-connector.js
+++ b/connector/elasticsearch-connector.js
@@ -877,6 +877,14 @@ var elasticsearchConnector = (function () {
     var processSearchResults = function (tableauDataMode, table, data) {
 
         var connectionData = JSON.parse(tableau.connectionData);
+
+        // Scroll may have timed-out or otherwise may not be available anymore
+        if(!data.hits){
+            log.info("[processSearchResults] - error in retrieving scroll results, response", JSON.stringify(data));
+            abortWithError("Error in retrieving scroll results");
+            return {results: [], scrollId: null, numProcessed: 0, more: false}
+        }
+
         searchHitsTotal = data.hits.total;
 
         console.log('[processSearchResults] total search hits: ' + searchHitsTotal);

--- a/connector/elasticsearch-connector.tmpl.html
+++ b/connector/elasticsearch-connector.tmpl.html
@@ -614,7 +614,6 @@
     <script src="moment.js" type="text/javascript"></script>
     <script src="ace.js" type="text/javascript"></script>
     <script src="humanize.js" type="text/javascript"></script>
-    <script src="q.js" type="text/javascript"></script>
     <script src="elasticsearch-connector.js" type="text/javascript"></script>
     <script src="aggregations.js" type="text/javascript"></script>
     <script src="tableauData.js" type="text/javascript"></script>


### PR DESCRIPTION
Detect 404 error returned from ES when scroll timeout is exceeded and report a more meaningful error.

Also remove usage of q library.