### PR TITLE
flags have to be provided to docker run before the tag is provided, not after

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ docker build docker -t <name of tag>
 and can then start a container, which will map the server to the host's port 3000 from this image with:
 
 ```
-docker run <name of tag> -p 3000:3000
+docker run -p 3000:3000 <name of tag>
 ```
 ## Running as a Windows service
 


### PR DESCRIPTION
When calling docker run, the tag's position is important. Everything after the tag is interpreted as the command to be run in the container, so the tag must go after the flags, but before any command being run in the container. Here there is no command, so it should go last
```
ubuntu@bh9-elasticsearch-tableau-connector:~$ docker run elasticsearch-tableau-connector -p 3000:3000
docker: Error response from daemon: OCI runtime create failed: container_linux.go:370: starting container process caused: exec: "-p": executable file not found in $PATH: unknown.
ERRO[0000] error waiting for container: context canceled
```
